### PR TITLE
Add `repository` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "linter"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/toplenboren/simple-pre-commit",
+  "repository": "https://github.com/toplenboren/simple-git-hooks",
   "lint-staged": {
     "*.js": "eslint"
   },


### PR DESCRIPTION
Adds the `repository` field in package.json to make the `npm repo` command working. Replaces the `homepage` field because npm can infer it from the `repository` field.