### PR TITLE
chore/add-new-hook

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,8 +8,8 @@ const {setHooksFromConfig} = require('./simple-git-hooks')
 
 try {
     setHooksFromConfig(process.cwd())
+    console.log('[INFO] Successfully set all git hooks')
 } catch (e) {
     console.log('[ERROR], Was not able to set git hooks. Error: ' + e)
 }
 
-console.log('[INFO] Successfully set all git hooks')

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -6,6 +6,7 @@ const VALID_GIT_HOOKS = [
     'applypatch-msg',
     'commit-msg',
     'fsmonitor-watchman',
+    'post-merge',
     'post-update',
     'pre-applypatch',
     'pre-commit',


### PR DESCRIPTION
I've attached the `post-merge` hook because it's really useful for me.

For example, I've this hook configured with Husky in order to reinstall the whole modules, verify the `package-lock.json` integrity and run an outdated checking process, after every branch merge.

The other change included in the `cli.js` file is related with the bewilderment that I had when the error message appears and just next, the info one telling me that everything was fine.

This is the reason why I moved the confirmation message to the `try` block.