### PR TITLE
Check the hook directory before write a hook command

### DIFF
--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -162,7 +162,13 @@ function _setHook(hook, command, projectRoot=process.cwd()) {
     const gitRoot = getGitProjectRoot(projectRoot)
 
     const hookCommand = "#!/bin/sh" + os.EOL + command
-    const hookPath = path.normalize(gitRoot + '/hooks/' + hook)
+    const hookDirectory = gitRoot + '/hooks/'
+    const hookPath = path.normalize(hookDirectory + hook)
+
+    const normalizedHookDirectory = path.normalize(hookDirectory)
+    if (!fs.existsSync(normalizedHookDirectory)) {
+        fs.mkdirSync(normalizedHookDirectory)
+    }
 
     fs.writeFileSync(hookPath, hookCommand)
     fs.chmodSync(hookPath, 0o0755)


### PR DESCRIPTION
Some tools (e.g. SourceTree, GitHub Desktop) do not create the hook directory. This ensures the hook directory before writing a hook command.