### PR TITLE
Fix some minor issues in recognition and loading of custom configs

### DIFF
--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -310,7 +310,9 @@ function _getConfigFromFile(projectRootPath, fileName) {
     }
 
     try {
-        const filePath = path.normalize(projectRootPath + '/' + fileName)
+        const filePath = path.isAbsolute(fileName)
+            ? fileName
+            : path.normalize(projectRootPath + '/' + fileName)
         if (filePath === __filename) {
             return undefined
         }

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -231,11 +231,10 @@ function _getPackageJson(projectPath = process.cwd()) {
  * @returns {string}
  */
 function _getCustomConfigPath(argv=[]) {
-    const cmdIdx = argv.findIndex(val => val === 'simple-git-hooks')
-
-    if (cmdIdx === -1) return ''
-    
-    return argv[cmdIdx + 1] || ''
+    // We'll run as one of the following:
+    // npx simple-git-hooks ./config.js
+    // node path/to/simple-git-hooks/cli.js ./config.js
+    return argv[2] || ''
 }
 
 /**

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -262,10 +262,13 @@ test('creates git hooks and removes unused but preserves specific git hooks', ()
     removeGitHooksFolder(projectWithUnusedConfigurationInPackageJsonPath)
 })
 
-test('creates git hooks and removes unused but preserves specific git hooks', () => {
+test.each([
+  ['npx', 'simple-git-hooks'],
+  ['node', require.resolve(`./cli`)],
+])('creates git hooks and removes unused but preserves specific git hooks for command: %s %s ./git-hooks.js', (command, arg1) => {
     createGitHooksFolder(projectWithCustomConfigurationFilePath)
 
-    spc.setHooksFromConfig(projectWithCustomConfigurationFilePath, ['npx', 'simple-git-hooks', './git-hooks.js'])
+    spc.setHooksFromConfig(projectWithCustomConfigurationFilePath, [command, arg1, './git-hooks.js'])
     const installedHooks = getInstalledGitHooks(path.normalize(path.join(projectWithCustomConfigurationFilePath, '.git', 'hooks')))
     expect(JSON.stringify(installedHooks)).toBe(JSON.stringify({'pre-commit':`#!/bin/sh\nexit 1`, 'pre-push':`#!/bin/sh\nexit 1`}))
 

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -263,12 +263,13 @@ test('creates git hooks and removes unused but preserves specific git hooks', ()
 })
 
 test.each([
-  ['npx', 'simple-git-hooks'],
-  ['node', require.resolve(`./cli`)],
-])('creates git hooks and removes unused but preserves specific git hooks for command: %s %s ./git-hooks.js', (command, arg1) => {
+  ['npx', 'simple-git-hooks', './git-hooks.js'],
+  ['node', require.resolve(`./cli`), './git-hooks.js'],
+  ['node', require.resolve(`./cli`), require.resolve(`${projectWithCustomConfigurationFilePath}/git-hooks.js`)],
+])('creates git hooks and removes unused but preserves specific git hooks for command: %s %s %s', (...args) => {
     createGitHooksFolder(projectWithCustomConfigurationFilePath)
 
-    spc.setHooksFromConfig(projectWithCustomConfigurationFilePath, [command, arg1, './git-hooks.js'])
+    spc.setHooksFromConfig(projectWithCustomConfigurationFilePath, args)
     const installedHooks = getInstalledGitHooks(path.normalize(path.join(projectWithCustomConfigurationFilePath, '.git', 'hooks')))
     expect(JSON.stringify(installedHooks)).toBe(JSON.stringify({'pre-commit':`#!/bin/sh\nexit 1`, 'pre-push':`#!/bin/sh\nexit 1`}))
 


### PR DESCRIPTION
The two issues:
1. The logic for finding the custom config command line argument would not work for all cases. In some cases the name of the binary would be the full path to `cli.js` so the check for `'simple-git-hooks'` wouldn't work. It's sufficient to assume the config file path will always be at index 2.
2. The config file loader assumes that the given path is relative to the project directory, but this isn't necessarily the case for a custom config path (I could provide it as an absolute path). I fixed this by checking whether the path is already absolute.