### PR TITLE
Allow string paths to configuration in package.json

### DIFF
--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -290,7 +290,8 @@ function _getConfig(projectRootPath, configFileName='') {
  */
 function _getConfigFromPackageJson(projectRootPath = process.cwd()) {
     const {packageJsonContent} = _getPackageJson(projectRootPath)
-    return packageJsonContent['simple-git-hooks']
+    const config = packageJsonContent['simple-git-hooks'];
+    return typeof config === 'string' ? _getConfig(config) : packageJsonContent['simple-git-hooks']
 }
 
 /**


### PR DESCRIPTION
This will allow users to specify a configuration path in `package.json`, instead of having to add a new configuration file when using shared config files. Follows the same pattern as Prettier:

```json
  "prettier": "@my-company/prettier-config",
  "simple-git-hooks": "@my-company/simple-git-hooks-config",
```