### PR TITLE
feat: support `deno`'s `node_modules` structure

### DIFF
--- a/.changeset/perfect-carrots-brake.md
+++ b/.changeset/perfect-carrots-brake.md
@@ -1,0 +1,5 @@
+---
+"simple-git-hooks": minor
+---
+
+feat: support `deno`'s `node_modules` structure

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -107,6 +107,10 @@ function getProjectRootDirectoryFromNodeModules(projectPath) {
     if (indexOfPnpmDir > -1) {
         return projDir.slice(0, indexOfPnpmDir - 1).join('/');
     }
+    const indexOfDenoDir = projDir.indexOf('.deno')
+    if (indexOfDenoDir > -1) {
+        return projDir.slice(0, indexOfDenoDir - 1).join('/');
+    }
 
     const indexOfStoreDir = projDir.indexOf('.store')
     if (indexOfStoreDir > -1) {

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -64,6 +64,14 @@ describe("Simple Git Hooks tests", () => {
             )
         ).toBe("var/my-project");
       });
+      
+      it("return correct dir when installed using deno:", () => {
+        expect(
+            simpleGitHooks.getProjectRootDirectoryFromNodeModules(
+                `var/my-project/node_modules/.deno/simple-git-hooks@${packageVersion}/node_modules/simple-git-hooks`
+            )
+        ).toBe("var/my-project");
+      });
     });
 
     describe("getGitProjectRoot", () => {


### PR DESCRIPTION
deno uses the same node_modules directory structure as pnpm, but currently `simple-git-hooks` assumes a flat (npm-style) structure which leads to an incorrect project path.

ref https://github.com/denoland/deno/issues/28735