### PR TITLE
fix: postinstall should ignore adding hooks if SKIP_INSTALL_SIMPLE_GI…

### DIFF
--- a/.changeset/bright-poets-beam.md
+++ b/.changeset/bright-poets-beam.md
@@ -1,0 +1,5 @@
+---
+"simple-git-hooks": patch
+---
+
+fix: postinstall should ignore adding hooks if SKIP_INSTALL_SIMPLE_GIT_HOOKS is defined

--- a/_tests/project_with_configuration_in_package_json/package.json
+++ b/_tests/project_with_configuration_in_package_json/package.json
@@ -5,6 +5,7 @@
     "pre-commit": "exit 1"
   },
   "devDependencies": {
+    "simple-git-hooks": "1.0.0",
     "simple-pre-commit": "1.0.0"
   }
 }

--- a/cli.js
+++ b/cli.js
@@ -4,13 +4,10 @@
 /**
  * A CLI tool to change the git hooks to commands from config
  */
-const {setHooksFromConfig} = require('./simple-git-hooks')
+const {setHooksFromConfig, skipInstall} = require('./simple-git-hooks')
 
-const {SKIP_INSTALL_SIMPLE_GIT_HOOKS} = process.env
-
-if (['1', 'true'].includes(SKIP_INSTALL_SIMPLE_GIT_HOOKS)) {
-    console.log(`[INFO] SKIP_INSTALL_SIMPLE_GIT_HOOKS is set to "${SKIP_INSTALL_SIMPLE_GIT_HOOKS}", skipping installing hook.`)
-    return
+if(skipInstall()) {
+    return;
 }
 
 setHooksFromConfig(process.cwd(), process.argv)

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
-const {checkSimpleGitHooksInDependencies, getProjectRootDirectoryFromNodeModules, setHooksFromConfig} = require("./simple-git-hooks");
+const {checkSimpleGitHooksInDependencies, getProjectRootDirectoryFromNodeModules, setHooksFromConfig, skipInstall} = require("./simple-git-hooks");
 
 
 /**
  * Creates the pre-commit from command in config by default
  */
 async function postinstall() {
+
+    if(skipInstall()) {
+        return;
+    }
+
     let projectDirectory;
 
     /* When script is run after install, the process.cwd() would be like <project_folder>/node_modules/simple-git-hooks

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -423,6 +423,15 @@ function _validateHooks(config) {
 
     return true
 }
+/** Checks if the environment variable for skipping hooks is defined. */
+function skipInstall() {
+    const {SKIP_INSTALL_SIMPLE_GIT_HOOKS} = process.env
+    if (['1', 'true'].includes(SKIP_INSTALL_SIMPLE_GIT_HOOKS)) {
+        console.log(`[INFO] SKIP_INSTALL_SIMPLE_GIT_HOOKS is set to "${SKIP_INSTALL_SIMPLE_GIT_HOOKS}", skipping installing hook.`)
+        return true;
+    }
+    return false;
+}
 
 module.exports = {
     checkSimpleGitHooksInDependencies,
@@ -430,5 +439,6 @@ module.exports = {
     getProjectRootDirectoryFromNodeModules,
     getGitProjectRoot,
     removeHooks,
+    skipInstall: skipInstall,
     PREPEND_SCRIPT
 }

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -439,6 +439,6 @@ module.exports = {
     getProjectRootDirectoryFromNodeModules,
     getGitProjectRoot,
     removeHooks,
-    skipInstall: skipInstall,
+    skipInstall,
     PREPEND_SCRIPT
 }

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -610,6 +610,40 @@ describe("Simple Git Hooks tests", () => {
           );
           expect(installedHooks).toEqual({ "pre-commit": TEST_SCRIPT });
         });
+
+        it("does not create git hooks during postinstall hook when SKIP_INSTALL_SIMPLE_GIT_HOOKS is set to 1", () => {
+          createGitHooksFolder(PROJECT_WITH_CONF_IN_PACKAGE_JSON);
+          execSync(`node ${require.resolve("./postinstall")}`, {
+            cwd: PROJECT_WITH_CONF_IN_PACKAGE_JSON,
+            env: {
+                ...process.env,
+                SKIP_INSTALL_SIMPLE_GIT_HOOKS: "1",
+            },
+          });
+          const installedHooks = getInstalledGitHooks(
+              path.normalize(
+                  path.join(PROJECT_WITH_CONF_IN_PACKAGE_JSON, ".git", "hooks")
+              )
+          );
+          expect(installedHooks).toEqual({});
+        });
+
+        it("creates git hooks during postinstall when SKIP_INSTALL_SIMPLE_GIT_HOOKS is set to 0", () => {
+          createGitHooksFolder(PROJECT_WITH_CONF_IN_PACKAGE_JSON);
+          execSync(`node ${require.resolve("./postinstall")}`, {
+            cwd: PROJECT_WITH_CONF_IN_PACKAGE_JSON,
+            env: {
+                ...process.env,
+                SKIP_INSTALL_SIMPLE_GIT_HOOKS: "0",
+            },
+          });
+          const installedHooks = getInstalledGitHooks(
+              path.normalize(
+                  path.join(PROJECT_WITH_CONF_IN_PACKAGE_JSON, ".git", "hooks")
+              )
+          );
+          expect(installedHooks).toEqual({ "pre-commit": TEST_SCRIPT });
+        });
       });
     });
 


### PR DESCRIPTION
Unsure if feature or bug (or me doing something wrong..) but  shouldn't `postinstall.js` behave like `cli.js`? i.e not adding any hooks if `SKIP_INSTALL_SIMPLE_GIT_HOOKS` is defined? 