### PR TITLE
fix: only get local `coore.hooksPath` config

### DIFF
--- a/.changeset/cold-falcons-pick.md
+++ b/.changeset/cold-falcons-pick.md
@@ -2,4 +2,4 @@
 "simple-git-hooks": patch
 ---
 
-just get config hooksPath local
+fix: only get local `coore.hooksPath` config

--- a/.changeset/cold-falcons-pick.md
+++ b/.changeset/cold-falcons-pick.md
@@ -1,0 +1,5 @@
+---
+"simple-git-hooks": patch
+---
+
+just get config hooksPath local

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -197,7 +197,7 @@ async function setHooksFromConfig(projectRootPath=process.cwd(), argv=process.ar
 function _getHooksDirPath(projectRoot) {
     const defaultHooksDirPath = path.join(projectRoot, '.git', 'hooks')
     try {
-        const customHooksDirPath = execSync('git config core.hooksPath', {
+        const customHooksDirPath = execSync('git config --local core.hooksPath', {
             cwd: projectRoot,
             encoding: 'utf8'
         }).trim()


### PR DESCRIPTION
git config core.hooksPath will get the global config probably，and will overwrite hooks with setHooksFromConfig function，and this will affect the other project。