### PR TITLE
fix the issue when gitRoot is not projectRoot

### DIFF
--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -195,14 +195,15 @@ async function setHooksFromConfig(projectRootPath=process.cwd(), argv=process.ar
  * @private
  */
 function _getHooksDirPath(projectRoot) {
-    const gitRoot = getGitProjectRoot(projectRoot)
-
-    if (!gitRoot) {
-        console.info('[INFO] No `.git` root folder found, skipping')
-        return
+    const getDefaultHooksDirPath = (projectRootPath) => {
+        const gitRoot = getGitProjectRoot(projectRootPath)
+        if (!gitRoot) {
+            console.info('[INFO] No `.git` root folder found, skipping')
+            return
+        }
+        return path.join(gitRoot, 'hooks')
     }
 
-    const defaultHooksDirPath = path.join(gitRoot, 'hooks')
     try {
         const customHooksDirPath = execSync('git config core.hooksPath', {
             cwd: projectRoot,
@@ -210,14 +211,14 @@ function _getHooksDirPath(projectRoot) {
         }).trim()
 
         if (!customHooksDirPath) {
-            return defaultHooksDirPath
+            return getDefaultHooksDirPath(projectRoot)
         }
 
         return path.isAbsolute(customHooksDirPath)
             ? customHooksDirPath
             : path.resolve(projectRoot, customHooksDirPath)
     } catch {
-        return defaultHooksDirPath
+        return getDefaultHooksDirPath(projectRoot)
     }
 }
 


### PR DESCRIPTION
Fix the issue 132

There is a bug in the install script when the gitRoot is not the same as the projectRoot. My Project looks like:
- .git
- npm_project_1
  - package.json
- npm_project_2
  - package.json
  - <- executing `npx simple-git-hooks` here

result:
- .git
- npm_project_1
  - package.json
- npm_project_2
  - .git
    - hooks
      - pre-commit
  - package.json

expectation:
- .git
  - hooks
    - pre-commit
- npm_project_1
  - package.json
- npm_project_2
  - package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for projects without a Git root or hooks directory, preventing errors and providing informative messages.
  * Ensured hook commands execute from the correct directory when hooks are stored outside the default location.
* **Tests**
  * Added coverage for monorepo setups to verify hooks install in the Git root directory.
  * Enhanced tests to confirm correct command execution context when custom hooks paths are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->