### PR TITLE
chore: remove some unnecessary ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
-node_modules
 .idea
 .git
-package-lock.json
 package.json


### PR DESCRIPTION
This pr aims to remove some unnecessary eslint ignore files.

The first file is `node_modules`.  It is included in eslint internally.

<img width="1688" height="1088" alt="image" src="https://github.com/user-attachments/assets/7b650122-75b8-492d-a6ac-b0ace396102e" />

The second file is `package-lock.json`. The recommended node package manager of this repo is `yarn`. So I think it is not necessary to ignore this file specially.

@JounQin please review it when you have time. If you have any suggestions, please tell me. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated linting configuration to refine ignored paths, improving consistency and alignment with the project structure.
  - Enhances developer tooling and code quality checks without affecting application features or behavior.
  - No changes to the user interface or performance; purely internal maintenance to streamline development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->