### PR TITLE
Support node_modules created with `bun install --linker=isolated`

### DIFF
--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -114,6 +114,10 @@ function getProjectRootDirectoryFromNodeModules(projectPath) {
     if (indexOfDenoDir > -1) {
         return projDir.slice(0, indexOfDenoDir - 1).join('/');
     }
+    const indexOfBunDir = projDir.indexOf('.bun')
+    if (indexOfBunDir > -1) {
+        return projDir.slice(0, indexOfBunDir - 1).join('/');
+    }
 
     const indexOfStoreDir = projDir.indexOf('.store')
     if (indexOfStoreDir > -1) {

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -72,6 +72,14 @@ describe("Simple Git Hooks tests", () => {
             )
         ).toBe("var/my-project");
       });
+
+      it("return correct dir when installed using bun with --linker=isolated", () => {
+        expect(
+            simpleGitHooks.getProjectRootDirectoryFromNodeModules(
+                `var/my-project/node_modules/.bun/simple-git-hooks@${packageVersion}/node_modules/simple-git-hooks`
+            )
+        ).toBe('var/my-project');
+      })
     });
 
     describe("getGitProjectRoot", () => {


### PR DESCRIPTION
Bun v1.2.19 added support for isolated installs similar to pnpm. This install strategy puts packages in `./node_modules/.bun`. For example, `simple-git-hooks@2.13.1` would exist in `./node_modules/.bun/simple-git-hooks@2.13.1/node_modules/simple-git-hooks`

This pr adds detection for `.bun` in `getProjectRootDirectoryFromNodeModules`

(https://github.com/oven-sh/bun/issues/21754)