### PR TITLE
Add CI detection to skip installing hooks

### DIFF
--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -462,6 +462,10 @@ function skipInstall() {
         console.log(`[INFO] SKIP_INSTALL_SIMPLE_GIT_HOOKS is set to "${SKIP_INSTALL_SIMPLE_GIT_HOOKS}", skipping installing hook.`)
         return true;
     }
+    if (require('is-ci')) {
+        console.log(`[INFO] CI detected, skipping installing hook.`)
+        return true
+    }
     return false;
 }
 


### PR DESCRIPTION
It's necessary to add `is-ci` to yarn lock .cc @toplenboren

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git hooks installation now automatically skips in continuous integration environments, improving performance and compatibility with automated build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->