### PR TITLE
README.md - better info about uninstall, manual uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ It causes errors for end users of your package
 pnpm uninstall simple-git-hooks
 ```
 
-Note: It only works for some 3rd-party package managers e.g. pnpm. For **npm** - default node package manager - it isn't supported, see [documentation](https://docs.npmjs.com/cli/v11/using-npm/scripts#a-note-on-a-lack-of-npm-uninstall-scripts).
+Note: It only works for some 3rd-party package managers e.g. pnpm. For **npm** - default node package manager - it isn't supported, see [documentation](https://docs.npmjs.com/cli/using-npm/scripts#a-note-on-a-lack-of-npm-uninstall-scripts).
 You can uninstall hooks manually from your project root
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -162,7 +162,14 @@ It causes errors for end users of your package
 > Uninstallation will remove all the existing git hooks.
 
 ```sh
-npm uninstall simple-git-hooks
+pnpm uninstall simple-git-hooks
+```
+
+Note: It only works for some 3rd-party package managers e.g. pnpm. For **npm** - default node package manager - it isn't supported, see [documentation](https://docs.npmjs.com/cli/v11/using-npm/scripts#a-note-on-a-lack-of-npm-uninstall-scripts).
+You can uninstall hooks manually from your project root
+
+```sh
+node node_modules/simple-git-hooks/uninstall.js
 ```
 
 ## Common issues

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ It causes errors for end users of your package
 pnpm uninstall simple-git-hooks
 ```
 
-Note: It only works for some 3rd-party package managers e.g. pnpm. For **npm** - default node package manager - it isn't supported, see [documentation](https://docs.npmjs.com/cli/using-npm/scripts#a-note-on-a-lack-of-npm-uninstall-scripts).
-You can uninstall hooks manually from your project root
+Note: It only works for some 3rd-party package managers e.g. pnpm. For **npm** - default node package manager - it isn't supported, see [documentation](https://docs.npmjs.com/cli/v11/using-npm/scripts#a-note-on-a-lack-of-npm-uninstall-scripts).
+You can uninstall hooks manually from your project root:
 
 ```sh
 node node_modules/simple-git-hooks/uninstall.js


### PR DESCRIPTION
npm as main package manage - doesn't support uninstall life cycle script.
I update the documentation and possibility to call uninstall script from node_modules as workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated uninstallation guidance: recommends using pnpm for automatic uninstall where supported, clarifies that automatic uninstallation varies across third-party package managers and is not supported for npm, and preserves instructions to perform a manual uninstall using the provided uninstall script as an alternative.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toplenboren/simple-git-hooks/pull/143)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->