### PR TITLE
fix: resolve project root via INIT_CWD in postinstall

### DIFF
--- a/.changeset/init-cwd-project-root.md
+++ b/.changeset/init-cwd-project-root.md
@@ -1,0 +1,5 @@
+---
+"simple-git-hooks": patch
+---
+
+fix: resolve the project root from `INIT_CWD` during postinstall so hooks install correctly on isolated `node_modules` layouts (pnpm, yarn, bun, and other package managers) regardless of the store directory name

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const {checkSimpleGitHooksInDependencies, getProjectRootDirectoryFromNodeModules, setHooksFromConfig, skipInstall} = require("./simple-git-hooks");
+const {checkSimpleGitHooksInDependencies, getProjectRootDirectory, setHooksFromConfig, skipInstall} = require("./simple-git-hooks");
 
 
 /**
@@ -12,17 +12,12 @@ async function postinstall() {
         return;
     }
 
-    let projectDirectory;
-
-    /* When script is run after install, the process.cwd() would be like <project_folder>/node_modules/simple-git-hooks
-       Here we try to get the original project directory by going upwards by 2 levels
-       If we were not able to get new directory we assume, we are already in the project root */
-    const parsedProjectDirectory = getProjectRootDirectoryFromNodeModules(process.cwd())
-    if (parsedProjectDirectory !== undefined) {
-        projectDirectory = parsedProjectDirectory
-    } else {
-        projectDirectory = process.cwd()
-    }
+    /* When the script is run after install, process.cwd() is the package's own
+       location inside node_modules (e.g. <project>/node_modules/simple-git-hooks,
+       or <project>/node_modules/.pnpm/... for isolated stores). getProjectRootDirectory
+       recovers the real project root — preferring INIT_CWD, which package managers
+       set to the install directory, and falling back to walking up from cwd. */
+    const projectDirectory = getProjectRootDirectory()
 
     if (checkSimpleGitHooksInDependencies(projectDirectory)) {
         try {

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -142,6 +142,31 @@ function getProjectRootDirectoryFromNodeModules(projectPath) {
 }
 
 /**
+ * Resolves the project root during the postinstall step.
+ *
+ * Prefers INIT_CWD — the directory the package manager was invoked from, which
+ * npm, pnpm, yarn, and bun all set to the project root when running lifecycle
+ * scripts. Unlike getProjectRootDirectoryFromNodeModules, it does not depend on
+ * the physical node_modules layout, so it resolves correctly for isolated stores
+ * whose directory name we don't recognize (and for future package managers)
+ * without hardcoding each store directory. Falls back to walking up from cwd
+ * when INIT_CWD is unavailable (e.g. the script is run directly, or by a tool
+ * that does not set INIT_CWD).
+ *
+ * @param {string | undefined} [initCwd] - value of process.env.INIT_CWD
+ * @param {string} [cwd] - current working directory
+ * @return {string} - an absolute path to the project root
+ */
+function getProjectRootDirectory(initCwd = process.env.INIT_CWD, cwd = process.cwd()) {
+    if (initCwd && fs.existsSync(path.join(initCwd, 'package.json'))) {
+        return initCwd
+    }
+
+    const parsedProjectDirectory = getProjectRootDirectoryFromNodeModules(cwd)
+    return parsedProjectDirectory !== undefined ? parsedProjectDirectory : cwd
+}
+
+/**
  * Checks the 'simple-git-hooks' in dependencies of the project
  * @param {string} projectRootPath
  * @throws TypeError if packageJsonData not an object
@@ -469,6 +494,7 @@ module.exports = {
     checkSimpleGitHooksInDependencies,
     setHooksFromConfig,
     getProjectRootDirectoryFromNodeModules,
+    getProjectRootDirectory,
     getGitProjectRoot,
     removeHooks,
     skipInstall,

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -82,6 +82,68 @@ describe("Simple Git Hooks tests", () => {
       })
     });
 
+    describe("getProjectRootDirectory", () => {
+      // __dirname is this repo's root, which contains a package.json — a stand-in
+      // for a real INIT_CWD (the directory a package manager runs postinstall from).
+      const realProjectRoot = __dirname;
+
+      // The test runner (npm/yarn/pnpm test) sets INIT_CWD itself, so clear it to
+      // keep each case hermetic; the value is passed explicitly where it matters.
+      let originalInitCwd;
+      beforeEach(() => {
+        originalInitCwd = process.env.INIT_CWD;
+        delete process.env.INIT_CWD;
+      });
+      afterEach(() => {
+        if (originalInitCwd === undefined) {
+          delete process.env.INIT_CWD;
+        } else {
+          process.env.INIT_CWD = originalInitCwd;
+        }
+      });
+
+      it("prefers INIT_CWD when it points at a directory with a package.json", () => {
+        // cwd is the package's physical location in an isolated store whose marker
+        // getProjectRootDirectoryFromNodeModules does not recognize — the layout
+        // that used to crash. INIT_CWD resolves the root regardless of the layout.
+        expect(
+            simpleGitHooks.getProjectRootDirectory(
+                realProjectRoot,
+                "/var/my-project/node_modules/.some-store/simple-git-hooks@2.13.1/node_modules/simple-git-hooks"
+            )
+        ).toBe(realProjectRoot);
+      });
+
+      it("falls back to the node_modules heuristic when INIT_CWD is unset", () => {
+        expect(
+            simpleGitHooks.getProjectRootDirectory(
+                undefined,
+                `/var/my-project/node_modules/.pnpm/simple-git-hooks@${packageVersion}/node_modules/simple-git-hooks`
+            )
+        ).toBe("/var/my-project");
+      });
+
+      it("ignores INIT_CWD when it does not point at a directory with a package.json", () => {
+        expect(
+            simpleGitHooks.getProjectRootDirectory(
+                path.join(realProjectRoot, "this-directory-does-not-exist"),
+                "/var/my-project/node_modules/simple-git-hooks"
+            )
+        ).toBe("/var/my-project");
+      });
+
+      it("falls back to cwd when INIT_CWD is unset and cwd is not inside node_modules", () => {
+        expect(
+            simpleGitHooks.getProjectRootDirectory(undefined, "/var/my-project")
+        ).toBe("/var/my-project");
+      });
+
+      it("reads process.env.INIT_CWD when called with no arguments", () => {
+        process.env.INIT_CWD = realProjectRoot;
+        expect(simpleGitHooks.getProjectRootDirectory()).toBe(realProjectRoot);
+      });
+    });
+
     describe("getGitProjectRoot", () => {
       const gitProjectRoot = path.normalize(path.join(__dirname, ".git"));
       const currentPath = path.normalize(path.join(__dirname));


### PR DESCRIPTION
## Problem

`postinstall.js` finds the project root by walking up from `process.cwd()` with `getProjectRootDirectoryFromNodeModules`. That walk recognizes a hardcoded set of store markers — `.pnpm`, `.deno`, `.bun`, `.store`. In an isolated `node_modules` layout, `process.cwd()` is the package's physical location inside the store (cwd resolves symlinks, so the top-level `node_modules/simple-git-hooks` symlink doesn't change it). When the store directory isn't one of the recognized markers, the walk falls through to the generic branch, strips `node_modules/<pkg>`, and lands on the dep-path slot — which has no `package.json`. `_getPackageJson` then throws an uncaught `ENOENT` and the install fails.

This is the pattern behind the per-package-manager additions already in this function (`.deno`, `.bun`): each new isolated store has to have its directory name added by hand, and any layout not yet enumerated crashes. Example, from an install whose store is named `.nub`:

```
Error: ENOENT: no such file or directory, stat '<project>/node_modules/.nub/simple-git-hooks@2.13.1/package.json'
    at _getPackageJson (simple-git-hooks.js)
    at checkSimpleGitHooksInDependencies (simple-git-hooks.js)
    at postinstall (postinstall.js)
```

## Fix

Prefer `process.env.INIT_CWD`. npm, pnpm, yarn, and bun all set `INIT_CWD` to the directory the install was invoked from — the project root — when running lifecycle scripts, so it is independent of the `node_modules` layout. Using it resolves the project root for every isolated store without enumerating store names, and covers package managers this file doesn't know about.

A new `getProjectRootDirectory(initCwd, cwd)` prefers `INIT_CWD` when it points at a directory containing a `package.json`, and falls back to the existing `getProjectRootDirectoryFromNodeModules` walk when `INIT_CWD` is unset — for example when the script is run directly rather than as a lifecycle hook. `getProjectRootDirectoryFromNodeModules` is unchanged, so its behavior and its tests are preserved; the fallback path is identical to today's logic.

## Verification

- Confirmed empirically that npm, pnpm, and bun each set `INIT_CWD` to the project root in a dependency's postinstall, while `cwd` is the package's store location.
- Added unit tests for `getProjectRootDirectory`: prefers a valid `INIT_CWD`, ignores an `INIT_CWD` with no `package.json`, falls back to the heuristic and then to `cwd`, and reads `process.env.INIT_CWD` by default.
- Reproduced the `ENOENT` against an unrecognized isolated store and confirmed the fix installs hooks cleanly, and confirmed a recognized `.pnpm` layout still resolves through the fallback with `INIT_CWD` unset — no change for existing package managers.

Fixes #112
Fixes #141

---

*Prepared with AI assistance.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hook installation during postinstall so the project root is detected correctly in isolated `node_modules` setups, including pnpm, yarn, and bun layouts.
  * Improved fallback behavior when the install location can’t be inferred, helping git hooks install more reliably across environments.

* **Tests**
  * Added coverage for project root detection and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->