### PR TITLE
fix: install and remove hooks correctly inside a git worktree

### DIFF
--- a/.changeset/shiny-donkeys-repeat.md
+++ b/.changeset/shiny-donkeys-repeat.md
@@ -2,4 +2,4 @@
 "simple-git-hooks": patch
 ---
 
-fix: install and remove hooks correctly inside a git worktree
+fix: install and remove hooks correctly inside a git worktree, including worktrees created with `git worktree add --relative-paths`

--- a/.changeset/shiny-donkeys-repeat.md
+++ b/.changeset/shiny-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"simple-git-hooks": patch
+---
+
+fix: install and remove hooks correctly inside a git worktree

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -79,7 +79,9 @@ function getGitProjectRoot(directory=process.cwd()) {
             let content = fs.readFileSync(fullPath, { encoding: 'utf-8' })
             let match = /^gitdir: (.*)\s*$/.exec(content)
             if (match) {
-                let gitDir = match[1]
+                // `git worktree add --relative-paths` writes a gitdir that is relative
+                // to the worktree, so resolve it against the .git file location
+                let gitDir = path.resolve(path.dirname(fullPath), match[1])
                 let commonDir = path.join(gitDir, 'commondir');
                 if (fs.existsSync(commonDir)) {
                     commonDir = fs.readFileSync(commonDir, 'utf8').trim();

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -201,14 +201,17 @@ async function setHooksFromConfig(projectRootPath=process.cwd(), argv=process.ar
 /**
  * Returns the absolute path to the Git hooks directory.
  * Respects user-defined core.hooksPath from Git config if present;
- * otherwise defaults to <gitRoot>/.git/hooks.
+ * otherwise defaults to <gitRoot>/hooks.
  *
- * @param {string} gitRoot - The absolute path to the Git project root
+ * @param {string} projectRoot - The absolute path to the working directory. A relative
+ *                               core.hooksPath is resolved against it, the same way git does
+ * @param {string} gitRoot - The absolute path to the .git directory. In a worktree this is
+ *                           the main repository's .git directory, which holds the shared hooks
  * @returns {string} - The resolved absolute path to the hooks directory
  * @private
  */
-function _getHooksDirPath(projectRoot) {
-    const defaultHooksDirPath = path.join(projectRoot, '.git', 'hooks')
+function _getHooksDirPath(projectRoot, gitRoot) {
+    const defaultHooksDirPath = path.join(gitRoot, 'hooks')
     try {
         const customHooksDirPath = execSync('git config --local core.hooksPath', {
             cwd: projectRoot,
@@ -246,7 +249,7 @@ function _setHook(hook, command, projectRoot=process.cwd()) {
     }
 
     const hookCommand = PREPEND_SCRIPT + command
-    const hookDirectory = _getHooksDirPath(projectRoot)
+    const hookDirectory = _getHooksDirPath(projectRoot, gitRoot)
     const hookPath = path.join(hookDirectory, hook)
 
     const normalizedHookDirectory = path.normalize(hookDirectory)
@@ -301,7 +304,14 @@ async function removeHooks(projectRoot = process.cwd()) {
  * @private
  */
 function _removeHook(hook, projectRoot=process.cwd()) {
-    const hookDirectory = _getHooksDirPath(projectRoot)
+    const gitRoot = getGitProjectRoot(projectRoot)
+
+    if (!gitRoot) {
+        console.info('[INFO] No `.git` root folder found, skipping')
+        return false
+    }
+
+    const hookDirectory = _getHooksDirPath(projectRoot, gitRoot)
     const hookPath = path.join(hookDirectory, hook)
 
     if (fs.existsSync(hookPath)) {

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -547,7 +547,16 @@ describe("Simple Git Hooks tests", () => {
       // In a worktree, hooks live in the main repository's .git/hooks
       const SHARED_HOOKS_DIR = path.join(MAIN_REPO, ".git", "hooks");
 
-      beforeEach(() => {
+      // git writes a relative gitdir into the worktree .git file only since 2.48
+      const supportsRelativePaths = execSync("git worktree add -h 2>&1 || true")
+          .toString()
+          .includes("relative-paths");
+
+      /**
+       * Creates a main repository with one linked worktree
+       * @param {string} worktreeAddFlags - extra flags for git worktree add
+       */
+      function createRepoWithWorktree(worktreeAddFlags = "") {
         fs.rmSync(WORKTREE_TEST_DIR, { recursive: true, force: true });
         fs.mkdirSync(MAIN_REPO, { recursive: true });
 
@@ -565,13 +574,17 @@ describe("Simple Git Hooks tests", () => {
         );
         git("add -A");
         git('commit -m init');
-        git(`worktree add ${LINKED_WORKTREE} -b linked-branch`);
+        git(`worktree add ${worktreeAddFlags} ${LINKED_WORKTREE} -b linked-branch`);
 
         // git init fills .git/hooks with *.sample files, drop them so that
         // the directory only contains what simple-git-hooks puts there
         for (const sample of fs.readdirSync(SHARED_HOOKS_DIR)) {
           fs.rmSync(path.join(SHARED_HOOKS_DIR, sample));
         }
+      }
+
+      beforeEach(() => {
+        createRepoWithWorktree();
       });
 
       afterEach(() => {
@@ -584,6 +597,20 @@ describe("Simple Git Hooks tests", () => {
         const installedHooks = getInstalledGitHooks(SHARED_HOOKS_DIR);
         expect(isEqual(installedHooks, COMMON_GIT_HOOKS)).toBe(true);
       });
+
+      // The test process runs from the package root, so this also covers the case
+      // where the current working directory is not the worktree itself
+      (supportsRelativePaths ? it : it.skip)(
+          "creates git hooks in the main repository when the worktree uses relative paths",
+          async () => {
+            createRepoWithWorktree("--relative-paths");
+
+            await simpleGitHooks.setHooksFromConfig(LINKED_WORKTREE);
+
+            const installedHooks = getInstalledGitHooks(SHARED_HOOKS_DIR);
+            expect(isEqual(installedHooks, COMMON_GIT_HOOKS)).toBe(true);
+          }
+      );
 
       it("removes git hooks from the main repository when run from a worktree", async () => {
         await simpleGitHooks.setHooksFromConfig(LINKED_WORKTREE);

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -539,6 +539,61 @@ describe("Simple Git Hooks tests", () => {
       })
     })
 
+    describe("Git worktree support", () => {
+      // A worktree needs a real git repository, so we create one under _tests
+      const WORKTREE_TEST_DIR = path.join(testsFolder, "tmp_worktree_project");
+      const MAIN_REPO = path.join(WORKTREE_TEST_DIR, "main");
+      const LINKED_WORKTREE = path.join(WORKTREE_TEST_DIR, "linked");
+      // In a worktree, hooks live in the main repository's .git/hooks
+      const SHARED_HOOKS_DIR = path.join(MAIN_REPO, ".git", "hooks");
+
+      beforeEach(() => {
+        fs.rmSync(WORKTREE_TEST_DIR, { recursive: true, force: true });
+        fs.mkdirSync(MAIN_REPO, { recursive: true });
+
+        const git = (cmd) => execSync(`git ${cmd}`, { cwd: MAIN_REPO, stdio: "ignore" });
+
+        git("init");
+        git("config user.email test@test.test");
+        git("config user.name test");
+        fs.writeFileSync(
+            path.join(MAIN_REPO, "package.json"),
+            JSON.stringify({
+              name: "worktree-project",
+              "simple-git-hooks": { "pre-commit": "exit 1", "pre-push": "exit 1" }
+            })
+        );
+        git("add -A");
+        git('commit -m init');
+        git(`worktree add ${LINKED_WORKTREE} -b linked-branch`);
+
+        // git init fills .git/hooks with *.sample files, drop them so that
+        // the directory only contains what simple-git-hooks puts there
+        for (const sample of fs.readdirSync(SHARED_HOOKS_DIR)) {
+          fs.rmSync(path.join(SHARED_HOOKS_DIR, sample));
+        }
+      });
+
+      afterEach(() => {
+        fs.rmSync(WORKTREE_TEST_DIR, { recursive: true, force: true });
+      });
+
+      it("creates git hooks in the main repository when run from a worktree", async () => {
+        await simpleGitHooks.setHooksFromConfig(LINKED_WORKTREE);
+
+        const installedHooks = getInstalledGitHooks(SHARED_HOOKS_DIR);
+        expect(isEqual(installedHooks, COMMON_GIT_HOOKS)).toBe(true);
+      });
+
+      it("removes git hooks from the main repository when run from a worktree", async () => {
+        await simpleGitHooks.setHooksFromConfig(LINKED_WORKTREE);
+        await simpleGitHooks.removeHooks(LINKED_WORKTREE);
+
+        const installedHooks = getInstalledGitHooks(SHARED_HOOKS_DIR);
+        expect(isEqual(installedHooks, {})).toBe(true);
+      });
+    });
+
     describe("CLI tests", () => {
       const testCases = [
         ["npx", "simple-git-hooks", "./git-hooks.js"],


### PR DESCRIPTION
Fixes #148

## Problem

In a git worktree, `.git` is a file, not a directory. `_getHooksDirPath()` builds the default hooks path as `path.join(projectRoot, '.git', 'hooks')`, so `mkdirSync` fails with `ENOTDIR` and no hook is installed.

This is a regression. #88 fixed worktrees (and closed #58), but 8bb9818 replaced `gitRoot + '/hooks/'` with `_getHooksDirPath(projectRoot)`. After that the resolved worktree path was no longer used, so the fix from #88 became dead code.

`_removeHook()` was changed in the same commit and had the same problem, so uninstall was broken in a worktree too.

## Change

`_getHooksDirPath()` now receives `gitRoot` and uses it for the default hooks directory. `getGitProjectRoot()` already returns the correct path in a worktree, because it follows the `gitdir:` line and the `commondir` file back to the main repository.

A relative `core.hooksPath` is still resolved against the working directory, because that is what git does. Only the default path uses `gitRoot`, so the husky migration flow from #127 is not affected.

`_removeHook()` gets the same fix, plus the `gitRoot` guard that `_setHook()` already had.

## Tests

Two new e2e tests build a real repository with `git init` and a real worktree with `git worktree add`, then check that hooks are installed into and removed from the main repository's `.git/hooks`.

Both tests fail on master with the `ENOTDIR` error above and pass with this change. The full suite passes (48 tests) and `yarn lint` is clean.

I also checked the fix by hand outside the test suite: after installing from a worktree with a `pre-commit` hook that exits 1, `git commit` inside the worktree is blocked. This shows git really resolves hooks to the directory we now write to.

A changeset is included as `patch`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Git hook installation and removal when working in Git worktrees.
  * Hooks are now placed in the shared repository hooks directory when configured from a worktree.
  * Improved handling of repositories using custom `core.hooksPath` settings.

* **Tests**
  * Added coverage verifying hook installation and removal across linked worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->