### PR TITLE
fix: skip postinstall when project has no package.json

### DIFF
--- a/.changeset/skip-when-no-package-json.md
+++ b/.changeset/skip-when-no-package-json.md
@@ -1,0 +1,5 @@
+---
+"simple-git-hooks": patch
+---
+
+fix: don't crash `postinstall` when the resolved project directory has no package.json — skip instead of throwing an uncaught ENOENT

--- a/simple-git-hooks.js
+++ b/simple-git-hooks.js
@@ -152,6 +152,12 @@ function checkSimpleGitHooksInDependencies(projectRootPath) {
         throw TypeError("Package json path is not a string!")
     }
 
+    // No package.json means we're not in a project that depends on simple-git-hooks
+    // (e.g. postinstall resolved to a directory without one) — skip instead of crashing.
+    if (!fs.existsSync(path.normalize(projectRootPath + '/package.json'))) {
+        return false
+    }
+
     const {packageJsonContent} = _getPackageJson(projectRootPath)
 
     // if simple-git-hooks in dependencies -> note user that he should remove move it to devDeps!
@@ -325,7 +331,7 @@ function _getPackageJson(projectPath = process.cwd()) {
 
     const targetPackageJson = path.normalize(projectPath + '/package.json')
 
-    if (!fs.statSync(targetPackageJson).isFile()) {
+    if (!fs.existsSync(targetPackageJson) || !fs.statSync(targetPackageJson).isFile()) {
         throw Error("Package.json doesn't exist")
     }
 

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -131,12 +131,17 @@ describe("Simple Git Hooks tests", () => {
       });
 
       it("returns false (does not throw) when package.json does not exist", () => {
-        const NON_EXISTENT_PROJECT = path.normalize(
-            path.join(process.cwd(), "_tests", "this_directory_does_not_exist")
+        // A directory that exists but has no package.json (the postinstall scenario in #112)
+        const dirWithoutPackageJson = fs.mkdtempSync(
+            path.join(process.cwd(), "_tests", "no_package_json_")
         );
-        expect(
-            simpleGitHooks.checkSimpleGitHooksInDependencies(NON_EXISTENT_PROJECT)
-        ).toBe(false);
+        try {
+          expect(
+              simpleGitHooks.checkSimpleGitHooksInDependencies(dirWithoutPackageJson)
+          ).toBe(false);
+        } finally {
+          fs.rmSync(dirWithoutPackageJson, { recursive: true, force: true });
+        }
       });
     });
   });

--- a/simple-git-hooks.test.js
+++ b/simple-git-hooks.test.js
@@ -129,6 +129,15 @@ describe("Simple Git Hooks tests", () => {
             simpleGitHooks.checkSimpleGitHooksInDependencies(PROJECT_WITHOUT_SIMPLE_GIT_HOOKS)
         ).toBe(false);
       });
+
+      it("returns false (does not throw) when package.json does not exist", () => {
+        const NON_EXISTENT_PROJECT = path.normalize(
+            path.join(process.cwd(), "_tests", "this_directory_does_not_exist")
+        );
+        expect(
+            simpleGitHooks.checkSimpleGitHooksInDependencies(NON_EXISTENT_PROJECT)
+        ).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #112

`postinstall.js` calls `checkSimpleGitHooksInDependencies(projectDirectory)` **outside** its try/catch. When the resolved project directory has no `package.json` (certain yarn/monorepo/CI layouts, as in #112), `_getPackageJson`'s `fs.statSync(...)` throws an uncaught `ENOENT` and **fails the whole install**.

**Fix:**
- `checkSimpleGitHooksInDependencies` returns `false` when there's no `package.json` (we're not in a project that depends on simple-git-hooks) → postinstall skips gracefully, matching the issue's "don't do anything when package.json not exists".
- `_getPackageJson` now guards with `fs.existsSync` so its documented `"Package.json doesn't exist"` error is actually thrown — the old `!fs.statSync(...).isFile()` was dead code because `statSync` threw first.

### Reproduced locally

Calling `checkSimpleGitHooksInDependencies` on a directory with no `package.json` (the postinstall path):

**Before (base `master`):**
```
CRASHED: ENOENT
```
**After (this PR):**
```
returned: false (no crash)
```

The added regression test also fails on `master` with `ENOENT: ... stat '.../package.json'` and passes with the fix. Full suite (47 tests) + eslint pass. Changeset (patch) included.

*Written with AI assistance; I've reviewed and tested the change and will maintain it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-install handling for project directories without a `package.json`.
  * Prevented uncaught errors when checking nonexistent or incomplete project directories.
  * Preserved existing validation for missing or invalid package files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->